### PR TITLE
Adds a namespace to all objects

### DIFF
--- a/add_ns/add_ns.yml
+++ b/add_ns/add_ns.yml
@@ -1,0 +1,8 @@
+#@ load ("@ytt:overlay", "overlay")
+#@ load ("@ytt:data", "data")
+
+#@overlay/match by=overlay.all,expects="1+"
+---
+metadata:
+  #@overlay/match by=overlay.subset(None),expects="0+"
+  namespace: #@ data.values.namespace

--- a/add_ns/values.yml
+++ b/add_ns/values.yml
@@ -1,0 +1,3 @@
+#@data/values
+---
+namespace: 


### PR DESCRIPTION
TL;DR
-----

Provides an overlay that adds a namespace to all objects

Details
-------

Implements an overlay that adds a namespace to all objects in
the processed manifests that don't already have one. It's a fairly
blunt tool since it specifies one namespace that is used for all
objects that aren't in one.
