### PR TITLE
Implements a template for a Contour TCP proxy

### DIFF
--- a/tcpproxy/_certificate.yml
+++ b/tcpproxy/_certificate.yml
@@ -1,0 +1,16 @@
+#@ load ("@ytt:data", "data")
+#@ if/end data.values.tls and not data.values.secret:
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: #@ "{}-tls".format(data.values.host)
+  namespace: #@ data.values.namespace
+spec:
+  secretName: #@ "{}-tls".format(data.values.host)
+  dnsNames:
+  - #@ data.values.host 
+  issuerRef:
+    name: #@ data.values.issuer 
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/tcpproxy/tcpproxy.yml
+++ b/tcpproxy/tcpproxy.yml
@@ -1,0 +1,23 @@
+#@ load ("@ytt:data", "data")
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: #@ data.values.name
+  #@ if/end data.values.namespace:
+  namespace: #@ data.values.namespace
+spec:
+  virtualhost:
+    fqdn: #@ data.values.host 
+    #@ if data.values.tls:
+    tls:
+      #@ if data.values.secret:
+      secretName: #@ data.values.secret
+      #@ else:
+      secretName: #@ "{}-tls".format(data.values.host)
+      #@ end
+    #@ end
+  tcpproxy:
+    services:
+    - name: #@ data.values.service.name
+      port: #@ data.values.service.port

--- a/tcpproxy/values.yml
+++ b/tcpproxy/values.yml
@@ -1,0 +1,15 @@
+#@data/values
+---
+name:
+namespace:
+
+ingress: concour
+tls: true
+websockets: false
+issuer: letsencrypt-production
+
+host:
+service:
+  name:
+  port: 
+secret:


### PR DESCRIPTION
TL;DR
-----

Adds a template for TCP proxying with Contour

Details
-------

Uses a Contour `HTTPProxy` to define a template for adding TCP
routing. The Contour team acknowledges that this is weird, but
we're stuck with the names they use for their CRDs.